### PR TITLE
Support psr/log v2 and v3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -72,11 +72,34 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: 7.4"
+          php-version: "7.4"
           ini-values: "memory_limit=-1"
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v2"
+
+      - name: "Run unit tests (PHPUnit)"
+        shell: "bash"
+        run: "composer test"
+
+  unit-tests-psr-log-v3:
+    name: "Unit tests (psr/log v3)"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.1"
+          ini-values: "memory_limit=-1"
+
+      - name: "Install dependencies with psr/log v3"
+        shell: "bash"
+        run: |
+          composer config platform.php 8.1
+          composer update --with psr/log:^3 --with-all-dependencies --no-interaction
 
       - name: "Run unit tests (PHPUnit)"
         shell: "bash"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^1.1 || ^3.0"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -52,7 +52,7 @@ class StderrLogger extends AbstractLogger
             if (is_object($level) && method_exists($level, '__toString')) {
                 $level = (string) $level;
             } else {
-                throw new InvalidArgumentException('Invalid log level: must be a string');
+                throw new InvalidArgumentException('Invalid log level: must be a string or stringable object');
             }
         }
 
@@ -79,7 +79,7 @@ class StderrLogger extends AbstractLogger
             if (is_object($message) && method_exists($message, '__toString')) {
                 $message = (string) $message;
             } else {
-                throw new InvalidArgumentException('Invalid log message: must be a string');
+                throw new InvalidArgumentException('Invalid log message: must be a string or stringable object');
             }
         }
 

--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -46,7 +46,7 @@ class StderrLogger extends AbstractLogger
         }
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         if (!isset(self::LOG_LEVEL_MAP[$level])) {
             throw new InvalidArgumentException("Invalid log level: {$level}");

--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -48,6 +48,14 @@ class StderrLogger extends AbstractLogger
 
     public function log($level, $message, array $context = []): void
     {
+        if (!is_string($level)) {
+            if (is_object($level) && method_exists($level, '__toString')) {
+                $level = (string) $level;
+            } else {
+                throw new InvalidArgumentException('Invalid log level: must be a string');
+            }
+        }
+
         if (!isset(self::LOG_LEVEL_MAP[$level])) {
             throw new InvalidArgumentException("Invalid log level: {$level}");
         }
@@ -65,6 +73,10 @@ class StderrLogger extends AbstractLogger
             }
 
             $context['exception'] = explode("\n", (string) $exception);
+        }
+
+        if (is_object($message) && method_exists($message, '__toString')) {
+            $message = (string) $message;
         }
 
         fwrite($this->stream, json_encode(compact('level', 'message', 'context')) . "\n");

--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -75,8 +75,12 @@ class StderrLogger extends AbstractLogger
             $context['exception'] = explode("\n", (string) $exception);
         }
 
-        if (is_object($message) && method_exists($message, '__toString')) {
-            $message = (string) $message;
+        if (!is_string($message)) {
+            if (is_object($message) && method_exists($message, '__toString')) {
+                $message = (string) $message;
+            } else {
+                throw new InvalidArgumentException('Invalid log message: must be a string');
+            }
         }
 
         fwrite($this->stream, json_encode(compact('level', 'message', 'context')) . "\n");

--- a/tests/Integration/IntegTestCase.php
+++ b/tests/Integration/IntegTestCase.php
@@ -102,7 +102,7 @@ class IntegTestCase extends TestCase
 
     protected function failOnLoggedErrors(): void
     {
-        $this->logger->method('error')->willReturnCallback(function (string $message, array $context) {
+        $this->logger->method('error')->willReturnCallback(function ($message, array $context) {
             $message = "Logged an error: {$message}\nContext:\n";
             foreach ($context as $key => $value) {
                 $message .= "- {$key}: {$value}\n";

--- a/tests/Integration/IntegTestCase.php
+++ b/tests/Integration/IntegTestCase.php
@@ -102,7 +102,7 @@ class IntegTestCase extends TestCase
 
     protected function failOnLoggedErrors(): void
     {
-        $this->logger->method('error')->willReturnCallback(function ($message, array $context) {
+        $this->logger->method('error')->willReturnCallback(function ($message, array $context = []) {
             $message = "Logged an error: {$message}\nContext:\n";
             foreach ($context as $key => $value) {
                 $message .= "- {$key}: {$value}\n";

--- a/tests/Integration/StderrLoggerTest.php
+++ b/tests/Integration/StderrLoggerTest.php
@@ -40,4 +40,13 @@ class StderrLoggerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $logger->log([], 'hello');
     }
+
+    public function testNonStringMessageThrowsInvalidArgumentException(): void
+    {
+        $stream = fopen('php://temp', 'a+');
+        $logger = new StderrLogger(LogLevel::DEBUG, $stream);
+
+        $this->expectException(InvalidArgumentException::class);
+        $logger->log(LogLevel::ERROR, []);
+    }
 }

--- a/tests/Integration/StderrLoggerTest.php
+++ b/tests/Integration/StderrLoggerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SlackPhp\Framework\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+use SlackPhp\Framework\StderrLogger;
+
+class StderrLoggerTest extends TestCase
+{
+    public function testStringableMessageIsRenderedAsStringInJsonLog(): void
+    {
+        $stream = fopen('php://temp', 'a+');
+        $logger = new StderrLogger(LogLevel::DEBUG, $stream);
+
+        $message = new class() {
+            public function __toString(): string
+            {
+                return 'stringable-message';
+            }
+        };
+
+        $logger->log(LogLevel::ERROR, $message, ['foo' => 'bar']);
+
+        rewind($stream);
+        $line = trim((string) stream_get_contents($stream));
+        $payload = json_decode($line, true);
+
+        $this->assertSame('stringable-message', $payload['message']);
+        $this->assertSame(LogLevel::ERROR, $payload['level']);
+        $this->assertSame(['foo' => 'bar'], $payload['context']);
+    }
+
+    public function testNonStringLevelThrowsInvalidArgumentException(): void
+    {
+        $stream = fopen('php://temp', 'a+');
+        $logger = new StderrLogger(LogLevel::DEBUG, $stream);
+
+        $this->expectException(InvalidArgumentException::class);
+        $logger->log([], 'hello');
+    }
+}


### PR DESCRIPTION
Composer require updated to "^1.1 || ^2.0 || ^3.0"
Updated StderrLogger log() to explicitly return void Relaxed integration test's error callback message parameter so Stringable-compatible values from psr/log v3 won't error, context not required